### PR TITLE
menu 컴포넌트 테일윈드 적용, recommended state 삭제

### DIFF
--- a/src/features/components/MenuRecommender.jsx
+++ b/src/features/components/MenuRecommender.jsx
@@ -12,38 +12,42 @@ function Menu() {
 
     const weather = useSelector((state) => state.weather.value)
     const temperature = useSelector((state) => state.temperature.value)
-    const { random, recommended } = useSelector((state) => state.menu) || {}
+    const { random } = useSelector((state) => state.menu)
 
     const handleRecommend = () => {
         dispatch(recommendedMenu({ weather, temperature }))
     }
-    console.log(weather)
-    console.log(temperature)
-    console.log(random)
 
+    console.log(random)
     return (
-        <section>
+        <section className="text-center">
             <h2
-                className={`${textColorClasses[weather] || 'text-weather-basic'} font-cafe24 [-webkit-text-stroke:1px_#FFFFFF]`}
+                className={`${textColorClasses[weather] || 'text-weather-basic'} m-6 text-7xl font-cafe24 [-webkit-text-stroke:1px_#FFFFFF]`}
             >
                 오늘 뭐 먹지?
             </h2>
-            <button onClick={handleRecommend}>
-                {random ? `${random.name}` : '추천 받기'}
-            </button>
-            {!recommended && <p>?</p>}
-            {recommended && (
-                <>
-                    <p>
-                        {random ? (
-                            <img src="/" alt={random.name} />
-                        ) : (
-                            '해당하는 음식이 없습니다 😢'
-                        )}
+
+            {random && (
+                <div className="">
+                    <img
+                        className="rounded-full mx-auto "
+                        src={random.src}
+                        alt={random.name}
+                    />
+                    <p
+                        className={`${textColorClasses[weather] || 'text-weather-basic'} m-6 text-4xl font-cafe24 [-webkit-text-stroke:1px_#FFFFFF]`}
+                    >
+                        {random.name}
                     </p>
-                    <button onClick={handleRecommend}>다시 추천 받기</button>
-                </>
+                </div>
             )}
+
+            <button
+                onClick={handleRecommend}
+                className="p-4 px-5 m-1 border border-gray-300 rounded-full text-4xl bg-white cursor-pointer font-cafe24 "
+            >
+                {random ? '다시 추천 받기' : '추천 받기'}
+            </button>
         </section>
     )
 }

--- a/src/features/slice/menuSlice.js
+++ b/src/features/slice/menuSlice.js
@@ -5,7 +5,6 @@ const menuSlice = createSlice({
     name: 'menu',
     initialState: {
         random: null,
-        recommended: false,
     },
     reducers: {
         recommendedMenu: (state, action) => {
@@ -22,8 +21,6 @@ const menuSlice = createSlice({
 
             const randomIndex = Math.floor(Math.random() * filtered.length)
             state.random = filtered[randomIndex]
-
-            state.recommended = true
         },
     },
 })


### PR DESCRIPTION
## #️⃣연관된 이슈> 
#19
## 📝작업 내용> 
- menu 컴포넌트 전체적인 디자인 적용
- 추천 받기 버튼과 다시 추천 받기 버튼을 합쳐서 조건부 렌더링으로 각각 렌더링하기
-  추천 받기 전에 미리 보여주던 음식 이미지 부분을 완전히 삭제함으로 recommended state가 필요 없어져서 삭제함
### 스크린샷 
<img width="586" height="522" alt="image" src="https://github.com/user-attachments/assets/12e1f506-b1d1-4d3b-94f2-1a5b92ccc192" />
<img width="769" height="895" alt="image" src="https://github.com/user-attachments/assets/d01817f9-227d-4237-9f49-9f2ef1562ad5" />
<img width="691" height="877" alt="image" src="https://github.com/user-attachments/assets/def6a96c-b904-420b-9352-56c680e32c29" />


